### PR TITLE
Refactor/datetime loop timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.4.0] - (2025-10-24)
+- Refactored `DateTimeLoopController` to use `Timer` for periodic updates instead of a `while` loop with `Future.delayed`, improving reliability and resource management.
+- Moved initial `DateTime` emission (when `triggerOnStart` is `true`) to `Future.microtask` to allow listeners to subscribe first.
+- Added `dispose` method in `DateTimeLoopBuilder` to properly cancel the timer and close the stream controller, preventing potential memory leaks.
+
 ## [1.3.1] - (2025-04-17)
 - Fixed `triggerOnStateChange` in `DateTimeLoopBuilder` to trigger immediate builds on init and parent rebuilds (Flutter issue #64916).
 - Updated example app’s Android code for Flutter > 3.27 compatibility.

--- a/lib/src/datetime_loop_builder.dart
+++ b/lib/src/datetime_loop_builder.dart
@@ -54,6 +54,12 @@ class _DateTimeLoopBuilderState extends State<DateTimeLoopBuilder> {
   }
 
   @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   void didUpdateWidget(covariant DateTimeLoopBuilder oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.timeUnit != widget.timeUnit ||

--- a/lib/src/utils/unique_key.dart
+++ b/lib/src/utils/unique_key.dart
@@ -1,9 +1,0 @@
-/// A simple class to represent a unique key, mimicking Flutter's UniqueKey.
-class UniqueKey {
-  final int _id = DateTime.now().millisecondsSinceEpoch;
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) || other is UniqueKey && _id == other._id;
-  @override
-  int get hashCode => _id.hashCode;
-}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: datetime_loop
 description: "A Flutter package that provides a widget to listen to the system's datetime and trigger a rebuild based on the specified time unit."
-version: 1.3.1
+version: 1.4.0
 repository: https://github.com/gnassro/datetime_loop
 issue_tracker: https://github.com/gnassro/datetime_loop/issues
 homepage: https://github.com/gnassro/datetime_loop


### PR DESCRIPTION
- Refactored `DateTimeLoopController` to use `Timer` for periodic updates instead of a `while` loop with `Future.delayed`, improving reliability and resource management.
- Moved initial `DateTime` emission (when `triggerOnStart` is `true`) to `Future.microtask` to allow listeners to subscribe first.
- Added `dispose` method in `DateTimeLoopBuilder` to properly cancel the timer and close the stream controller, preventing potential memory leaks.